### PR TITLE
XML configuration for phpunit

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,9 @@
+<phpunit
+        colors="true"
+        processIsolation="true">
+    <testsuites>
+        <testsuite name="AllTests">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>


### PR DESCRIPTION
This enables us to merely run ./phpunit without any extra parameters. It points it to the "tests/" folder, and ensures that we run the tests in isolation mode. It also makes the terminal testing colourful for ease of use and a rainbow life :)
